### PR TITLE
Update kube-rbac-proxy image location.

### DIFF
--- a/riverbed-operator.yaml
+++ b/riverbed-operator.yaml
@@ -613,7 +613,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
From gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1 to quay.io/brancz/kube-rbac-proxy:v0.13.1