### PR TITLE
Change cert-manager, upgrade, and auto-instrumentation on cluster restart documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ kubectl get pods --namespace cert-manager
 ```
 
 **Install  [cert-manager](https://cert-manager.io/docs/installation/) in your cluster**
-```
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
-```
 
 Before installing the Riverbed Operator make sure the cert-manager-webhook is fully installed.
 Some installs may take up to thirty seconds to complete. Run the command below and verify READY is 1/1

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ For simplicity, `kubectl` is used in the instructions below and will work in bot
 # Install cert-manager
 The Riverbed Operator requires that  [cert-manager](https://cert-manager.io/docs/installation/) is installed in your cluster and that your cluster uses Kubernetes version 1.26 or greater. The cert-manager is used for auto-instrumentation of Java and .NET applications.
 
-**Check if cert-manager is installed on your cluster**
+**Check if cert-manager is installed**
 ```
 kubectl get pods --namespace cert-manager
 ```
 
-**Install  [cert-manager](https://cert-manager.io/docs/installation/) in your cluster**
+**Install  [cert-manager](https://cert-manager.io/docs/installation/) if not already installed**
 
 Before installing the Riverbed Operator make sure the cert-manager-webhook is fully installed.
 Some installs may take up to thirty seconds to complete. Run the command below and verify READY is 1/1

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ kubectl delete -f https://raw.githubusercontent.com/riverbed/riverbed-operator/v
 ```
 Minor 2.x upgrades can be applied by simply running the install instructions above.
 
+After an upgrade, you should restart any instrumented applications that were started prior to the upgrade.
+
 # Configure the Riverbed Operator
 The Customer ID and Analysis Server Host will need to be configured for the APM Agent. Additional configuration may be required (outlined below)
 ```

--- a/README.md
+++ b/README.md
@@ -174,6 +174,22 @@ Here we are patching an existing .NET deployment to disable instrumentation
 kubectl patch deployment <application-deployment-name> --type=json -p='[{"op": "remove", "path": "/spec/template/metadata/annotations/instrument.apm.riverbed~1inject-dotnet"}]'
 ```
 
+# Auto instrumented applications and cluster restart.
+On a Kubernetes cluster restart, applications may fail to instrument if they start before the Riverbed Operator.  To mitigate this behavior you may need to redeploy the instrumented application.   
+
+You can also change the scheduling order of the instrumented application (using the steps below).      
++ Restrict the riverbed-operator to instrument applications in certain namespaces. 
+For example to restrict the riverbed-operator to applications running in the "apps" or "default" namespace
+```
+kubectl patch mutatingwebhookconfiguration riverbed-operator-mutating-webhook-configuration --type='json' -p='[{"op": "add", "path": "/webhooks/0/namespaceSelector", "value": {"matchExpressions": [{"key": "kubernetes.io/metadata.name", "operator": "In", "values": ["apps", "default"]}]}}]'
+```
+
++ Change the riverbed-operator-mutating-webhook-configuration failure policy
+```
+kubectl patch mutatingwebhookconfiguration riverbed-operator-mutating-webhook-configuration --type='json' -p='[{"op": "replace", "path": "/webhooks/0/failurePolicy", "value": "Fail"}]'
+```
+Changing the failurePolicy to fail must be done with caution as it can affect the startup order and timing for Kubernetes pods.
+
 # Legal
 © 2025 Riverbed Technology LLC All rights reserved.
 


### PR DESCRIPTION
- Remove unsupported cert-manager version.
- Clarification on upgrade.
- Document issues and workarounds for cluster restart.