### PR TITLE
Include the registry with all image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ spec:
     spec:
       containers:
       - name: spring-app
-        image: springio/gs-spring-boot-docker
+        image: docker.io/springio/gs-spring-boot-docker
         ports:
         - containerPort: 8080
 EOF

--- a/riverbed-operator-openshift.yaml
+++ b/riverbed-operator-openshift.yaml
@@ -765,12 +765,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: riverbed/riverbed-java-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.0.1-1
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: riverbed/riverbed-dotnet-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.0.1-1
         - name: RVBD_APM_AGENT_IMAGE
-          value: riverbed/riverbed-apm-agent:2.0.1-1
-        image: riverbed/riverbed-operator:2.0.1-9
+          value: docker.io/riverbed/riverbed-apm-agent:2.0.1-1
+        image: docker.io/riverbed/riverbed-operator:2.0.1-9
         livenessProbe:
           httpGet:
             path: /healthz

--- a/riverbed-operator.yaml
+++ b/riverbed-operator.yaml
@@ -738,12 +738,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: riverbed/riverbed-java-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.0.1-1
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: riverbed/riverbed-dotnet-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.0.1-1
         - name: RVBD_APM_AGENT_IMAGE
-          value: riverbed/riverbed-apm-agent:2.0.1-1
-        image: riverbed/riverbed-operator:2.0.1-9
+          value: docker.io/riverbed/riverbed-apm-agent:2.0.1-1
+        image: docker.io/riverbed/riverbed-operator:2.0.1-9
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
`short_name_mode` is a configuration option in CRI-O (the container runtime that many Kubernetes distributions use, including OpenShift). On a technical level, it’s not part of the Kubernetes API or a Kubernetes “feature” but instead is a container runtime configuration.

The config had been around prior to Kubernetes 1.34 but it became more noticed because Kubernetes 1.34 released with CRI-O 1.34 as the container runtime. The default setting for `short_name_mode` is now `enforcing` (which means it fails if the image could match more than one registry): https://github.com/grafana/helm-charts/issues/3923

The recommendation is to include the registry in image names to avoid ambiguity.