### PR TITLE
2.1.0

### DIFF
--- a/riverbed-operator-openshift.yaml
+++ b/riverbed-operator-openshift.yaml
@@ -765,12 +765,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-java-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-5
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-5
         - name: RVBD_APM_AGENT_IMAGE
-          value: docker.io/riverbed/riverbed-apm-agent:2.0.1-1
-        image: docker.io/riverbed/riverbed-operator:2.0.1-9
+          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-5
+        image: docker.io/riverbed/riverbed-operator:2.1.0-8
         livenessProbe:
           httpGet:
             path: /healthz

--- a/riverbed-operator-openshift.yaml
+++ b/riverbed-operator-openshift.yaml
@@ -765,12 +765,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-5
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-7
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-5
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-7
         - name: RVBD_APM_AGENT_IMAGE
-          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-5
-        image: docker.io/riverbed/riverbed-operator:2.1.0-8
+          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-7
+        image: docker.io/riverbed/riverbed-operator:2.1.0-12
         livenessProbe:
           httpGet:
             path: /healthz

--- a/riverbed-operator.yaml
+++ b/riverbed-operator.yaml
@@ -738,12 +738,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-5
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-7
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-5
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-7
         - name: RVBD_APM_AGENT_IMAGE
-          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-5
-        image: docker.io/riverbed/riverbed-operator:2.1.0-8
+          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-7
+        image: docker.io/riverbed/riverbed-operator:2.1.0-12
         livenessProbe:
           httpGet:
             path: /healthz

--- a/riverbed-operator.yaml
+++ b/riverbed-operator.yaml
@@ -738,12 +738,12 @@ spec:
         - /manager
         env:
         - name: RVBD_JAVA_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-java-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-java-instrumentation:2.1.0-5
         - name: RVBD_DOTNET_INSTRUMENTATION_IMAGE
-          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.0.1-1
+          value: docker.io/riverbed/riverbed-dotnet-instrumentation:2.1.0-5
         - name: RVBD_APM_AGENT_IMAGE
-          value: docker.io/riverbed/riverbed-apm-agent:2.0.1-1
-        image: docker.io/riverbed/riverbed-operator:2.0.1-9
+          value: docker.io/riverbed/riverbed-apm-agent:2.1.0-5
+        image: docker.io/riverbed/riverbed-operator:2.1.0-8
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The Riverbed Operator 2.1.0 release addresses security fixes by updating to version 9.7-1776833838 of the Universal Base Image.

This release uses the 13.2.1-502 release of our APM Agent.